### PR TITLE
invoke get from config_manager (fixes #6)

### DIFF
--- a/docs/tasks/config.md
+++ b/docs/tasks/config.md
@@ -5,7 +5,7 @@ target store.  The `config` function consumes existing `git_datastore`.
 The device's configuration to be stored in GIT repository and merged in upstream
 master branch, allowing the comparison (diff) of any content in the store.
 
-The `ansible_network_provider` is used to gather configuration content from devices.
+The `ansible-network.config_manager` is used to gather configuration content from devices.
 
 ## How to save and merge content in the content store
 
@@ -40,7 +40,7 @@ The example playbook above will :
 
 ## Function Parameters (Specs)
 
-For additional details about variables supported by this role and theirs respective default values [config_spec](https://github.com/ansible-network.config_store/blob/devel/meta/config_spec.yaml)
+For additional details about variables supported by this role and theirs respective default values [config_spec](https://github.com/ansible-network.content_store/blob/devel/meta/config_spec.yaml)
 
 ## Notes
 None

--- a/tasks/config.yaml
+++ b/tasks/config.yaml
@@ -5,10 +5,10 @@
   validate_role_spec:
     spec: config_spec.yaml
 
-- name: "invoke network provider get_config function"
+- name: "invoke get from config_manager"
   include_role:
-    name: "{{ ansible_network_provider }}"
-    tasks_from: get_config
+    name: "ansible-network.config_manager"
+    tasks_from: get
 
 - name: "validate configuration exists"
   fail:


### PR DESCRIPTION
Use `ansible-network.config_manager/get` to gather configuration from the device, instead of the `{{ ansible_network_provider }}/get_config`.